### PR TITLE
feat(device): add vCPU ID parameter to device operations

### DIFF
--- a/axdevice_base/src/lib.rs
+++ b/axdevice_base/src/lib.rs
@@ -45,7 +45,7 @@ pub trait BaseDeviceOps {
     /// Returns the address range of the emulated device.
     fn address_range(&self) -> AddrRange<GuestPhysAddr>;
     /// Handles a read operation on the emulated device.
-    fn handle_read(&self, addr: GuestPhysAddr, width: usize) -> AxResult<usize>;
+    fn handle_read(&self, addr: GuestPhysAddr, width: usize, vcpu_id: usize) -> AxResult<usize>;
     /// Handles a write operation on the emulated device.
-    fn handle_write(&self, addr: GuestPhysAddr, width: usize, val: usize);
+    fn handle_write(&self, addr: GuestPhysAddr, width: usize, val: usize, vcpu_id: usize);
 }


### PR DESCRIPTION
- Add vcpu_id parameter to handle_read and handle_write methods
- This enhancement allows device operations to be aware of the specific virtual CPU performing the operation